### PR TITLE
No border right if more than two buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
             This won't show anything visually. You need to use JavaScript APIs to show / hide it.
         </p>
 <pre>
-&lt;pure-dialog id="example" title="Pure Dialog Demo" buttons="Absolutely, No"&gt;
+&lt;pure-dialog id="example" title="Pure Dialog Demo" buttons="Absolutely, No, Maybe"&gt;
     Is this project worth a star?
 &lt;/pure-dialog&gt;
 </pre>
@@ -95,7 +95,7 @@ document.addEventListener('pure-dialog-button-clicked', function(e) {
             alert(e.detail + ' clicked!');
         });
     </script>
-    <pure-dialog id="example" title="Pure Dialog Demo" buttons="Absolutely, No">
+    <pure-dialog id="example" title="Pure Dialog Demo" buttons="Absolutely, No, Maybe">
         Is this project worth a star?
     </pure-dialog>
     </body>

--- a/src/pure-dialog.css
+++ b/src/pure-dialog.css
@@ -100,6 +100,9 @@ pure-dialog .pure-dialog-button {
     height: auto;
 }
 
-pure-dialog .pure-dialog-button:first-child { 
+pure-dialog .pure-dialog-button {
     border-right: 1px solid #ccc; 
+}
+pure-dialog .pure-dialog-button:nth-last-child(1) {
+    border-right: 0;
 }


### PR DESCRIPTION
By default, have border-right style for all pure-dialog-button
Then use nth-last-child(1) to remove border on the final button

Compatibility of nth-last-child:
IE9+
Firefox 3.5+
Chrome
Safari
Opera